### PR TITLE
Dockerize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM alpine:latest
+
+RUN apk --no-cache update && \
+    apk --no-cache add wget make perl perl-app-cpanminus \
+      perl-readonly perl-dev perl-params-util perl-file-remove perl-clone \
+      perl-class-inspector perl-test-deep perl-task-weaken perl-list-moreutils \
+      perl-exception-class perl-module-pluggable perl-module-build \
+      perl-file-sharedir perl-path-tiny perl-class-tiny perl-config-tiny && \
+    rm -rf /var/cache/apk/*
+
+RUN cpanm B::Keywords && \
+    cpanm IO::String && \
+    cpanm Test::Object && \
+    cpanm Hook::LexWrap && \
+    cpanm Test::SubCalls && \
+    cpanm PPI::Token::Quote::Single && \
+    cpanm PPIx::QuoteLike && \
+    cpanm PPIx::Utilities::Statement && \
+    cpanm PPIx::Regexp && \
+    cpanm String::Format && \
+    cpanm Perl::Tidy && \
+    cpanm Lingua::EN::Inflect && \
+    cpanm Pod::Spell && \
+    rm -rf /root/.cpanm
+
+COPY lib /usr/local/lib/perl5/site_perl
+
+COPY bin /usr/local/bin
+RUN chmod +x /usr/local/bin/perlcritic
+
+ENTRYPOINT [ "/usr/local/bin/perlcritic" ]
+CMD [ "--help" ]

--- a/lib/Perl/Critic/Policy/ErrorHandling/RequireCheckingReturnValueOfEval.pm
+++ b/lib/Perl/Critic/Policy/ErrorHandling/RequireCheckingReturnValueOfEval.pm
@@ -366,7 +366,7 @@ true value and to test that value:
     # Constructors are no problem.
     my $object = eval { Class->new() };
 
-    # To cover the possiblity that an operation may correctly return a
+    # To cover the possibility that an operation may correctly return a
     # false value, end the block with "1":
     if ( eval { something(); 1 } ) {
         ...


### PR DESCRIPTION
# Overview

Creates a Docker Image which contains all the required perl libs.

# Build Docker Image:

docker build -t image:label .

# Use the image

The docker image will execute the `./bin/perlcritic` script, and arguments to the `docker run` command will be passed to the `perlcritic`

## Invoke
`docker run image:label [perlcritic options]`